### PR TITLE
Remove `transformOutput` combinator

### DIFF
--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -1,8 +1,7 @@
-import type { Either, Right } from '@matt.kantor/either'
+import type { Right } from '@matt.kantor/either'
 import * as either from '@matt.kantor/either'
 import { nothing } from './constructors.js'
 import type {
-  InvalidInputError,
   Parser,
   ParserResult,
   ParserWhichAlwaysSucceeds,
@@ -185,21 +184,6 @@ export const sequence =
   }
 type SequenceOutput<Parsers extends readonly Parser<unknown>[]> = {
   [Index in keyof Parsers]: OutputOf<Parsers[Index]>
-}
-
-/**
- * Refine/transform the output of `parser` via a function which may fail.
- */
-export const transformOutput = <Output, NewOutput>(
-  parser: Parser<Output>,
-  f: (output: Output) => Either<InvalidInputError, NewOutput>,
-): Parser<NewOutput> => {
-  const transformation = (success: Success<Output>) =>
-    either.map(f(success.output), output => ({
-      output,
-      remainingInput: success.remainingInput,
-    }))
-  return input => either.flatMap(parser(input), transformation)
 }
 
 /**

--- a/src/parsing.test.ts
+++ b/src/parsing.test.ts
@@ -11,7 +11,6 @@ import {
   oneOf,
   oneOrMore,
   sequence,
-  transformOutput,
   zeroOrMore,
 } from './combinators.js'
 import {
@@ -129,21 +128,6 @@ suite('combinators', _ => {
     assertSuccess(ab('ab'), ['a', 'b'])
     assertSuccess(ab('abc'), ['a', 'b'])
     assertFailure(ab('bab'))
-  })
-
-  test('transformOutput', _ => {
-    const aTransformedToUppercase = transformOutput(literal('a'), a =>
-      either.makeRight(a.toUpperCase()),
-    )
-    assertSuccess(aTransformedToUppercase('a'), 'A')
-    assertSuccess(aTransformedToUppercase('ab'), 'A')
-    assertFailure(aTransformedToUppercase('b'))
-    assertFailure(aTransformedToUppercase(''))
-    assertFailure(
-      transformOutput(anySingleCharacter, _ =>
-        either.makeLeft({ kind: 'invalidInput', input: '', message: '' }),
-      )(''),
-    )
   })
 
   test('zeroOrMore', _ => {


### PR DESCRIPTION
The fact that `transformOutput` required an `InvalidInputError` to be explicitly created in order to model failure made this function difficult to use (you had to keep track of your own `input`, etc). I considered changing the signature to instead only require an error message, but ultimately decided to ditch it entirely for now. Either change is semver-major and I don't currently use `transformOutput` at all (and I believe I'm still the sole consumer of this package).