### PR TITLE
Support Node.js 22.18+ as a test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf dist* *.tsbuildinfo",
     "build": "tsc --build tsconfig.lib.json",
     "build:tests": "tsc --project tsconfig.lib.json --outDir dist-test --declarationDir dist && tsc --build tsconfig.test.json",
-    "test": "npm run build:tests && node --test"
+    "test": "npm run build:tests && node --test --no-experimental-strip-types"
   },
   "type": "module"
 }


### PR DESCRIPTION
Now that type-stripping is supported by default, `node --test` tries to open the `*.test.ts` files directly, which fails. For more see <https://github.com/mkantor/please-lang-prototype/pull/75>.