### PR TITLE
Return narrower non-readonly arrays from parsers

### DIFF
--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -146,7 +146,7 @@ type OneOfOutput<Parsers extends readonly Parser<unknown>[]> = {
  */
 export const oneOrMore = <Output>(
   parser: Parser<Output>,
-): Parser<readonly [Output, ...(readonly Output[])]> =>
+): Parser<[Output, ...(readonly Output[])]> =>
   map(sequence([parser, zeroOrMore(parser)]), ([head, tail]) => [head, ...tail])
 
 /**
@@ -181,7 +181,7 @@ export const sequence =
     return parseResult as ParserResult<SequenceOutput<Parsers>>
   }
 type SequenceOutput<Parsers extends readonly Parser<unknown>[]> = {
-  [Index in keyof Parsers]: OutputOf<Parsers[Index]>
+  -readonly [Index in keyof Parsers]: OutputOf<Parsers[Index]>
 }
 
 /**
@@ -189,9 +189,7 @@ type SequenceOutput<Parsers extends readonly Parser<unknown>[]> = {
  * Outputs are collected in an array.
  */
 export const zeroOrMore =
-  <Output>(
-    parser: Parser<Output>,
-  ): ParserWhichAlwaysSucceeds<readonly Output[]> =>
+  <Output>(parser: Parser<Output>): ParserWhichAlwaysSucceeds<Output[]> =>
   // Uses a loop rather than recursion to avoid stack overflow.
   input => {
     const output: Output[] = []

--- a/src/parsing.test.ts
+++ b/src/parsing.test.ts
@@ -213,11 +213,10 @@ test('README example', _ => {
 const longInputLength = 10000
 const longInput = 'a'.repeat(longInputLength)
 const longInputElementParser = literal('a')
-// Written oddly to prove non-emptiness.
-const longExpectedOutput = [
-  'a',
-  ...Array.from({ length: longInputLength - 1 }, _ => 'a' as const),
-] as const
+const longExpectedOutput = Array.from(
+  { length: longInputLength },
+  _ => 'a' as const,
+)
 
 const adjustStartStackFn = (
   error: AssertionError,


### PR DESCRIPTION
If a caller really wants to mutate the array returned from a parser built using `sequence`, `oneOrMore`, or `zeroOrMore`, it can't cause any trouble for this library, so allow it.